### PR TITLE
Add support for class selection during workflows

### DIFF
--- a/src/main/java/org/fenixedu/academic/ui/struts/action/student/enrollment/EnrolmentContextHandler.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/student/enrollment/EnrolmentContextHandler.java
@@ -32,6 +32,8 @@ public abstract class EnrolmentContextHandler {
 
     public abstract Optional<String> getReturnURLForStudentInClasses(HttpServletRequest request, Registration registration);
 
+    public abstract Optional<String> getReturnURLForStudentInFullClasses(HttpServletRequest request, Registration registration);
+
     public static class DefaultEnrolmentContextHandler extends EnrolmentContextHandler {
 
         @Override
@@ -46,6 +48,11 @@ public abstract class EnrolmentContextHandler {
                     GenericChecksumRewriter.injectChecksumInUrl(request.getContextPath(), link, request.getSession());
             return Optional.of(injectedLink);
 
+        }
+
+        @Override
+        public Optional<String> getReturnURLForStudentInFullClasses(HttpServletRequest request, Registration registration) {
+            return Optional.empty();
         }
 
     }

--- a/src/main/java/org/fenixedu/academic/ui/struts/action/student/enrollment/SchoolClassStudentEnrollmentDA.java
+++ b/src/main/java/org/fenixedu/academic/ui/struts/action/student/enrollment/SchoolClassStudentEnrollmentDA.java
@@ -5,9 +5,11 @@ package org.fenixedu.academic.ui.struts.action.student.enrollment;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -18,12 +20,13 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.fenixedu.academic.domain.Degree;
 import org.fenixedu.academic.domain.EnrolmentPeriod;
-import org.fenixedu.academic.domain.EnrolmentPeriodInClasses;
+import org.fenixedu.academic.domain.EnrolmentPeriodInClassesCandidate;
 import org.fenixedu.academic.domain.ExecutionCourse;
 import org.fenixedu.academic.domain.ExecutionSemester;
 import org.fenixedu.academic.domain.Lesson;
 import org.fenixedu.academic.domain.SchoolClass;
 import org.fenixedu.academic.domain.Shift;
+import org.fenixedu.academic.domain.StudentCurricularPlan;
 import org.fenixedu.academic.domain.exceptions.DomainException;
 import org.fenixedu.academic.domain.student.Registration;
 import org.fenixedu.academic.domain.student.Student;
@@ -35,6 +38,8 @@ import org.fenixedu.bennu.struts.annotations.Mapping;
 import org.fenixedu.bennu.struts.portal.EntryPoint;
 import org.fenixedu.bennu.struts.portal.StrutsFunctionality;
 import org.joda.time.DateTime;
+
+import pt.ist.fenixframework.FenixFramework;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
@@ -59,9 +64,34 @@ public class SchoolClassStudentEnrollmentDA extends FenixDispatchAction {
 
         final List<SchoolClassStudentEnrollmentDTO> enrollmentBeans = new ArrayList<SchoolClassStudentEnrollmentDTO>();
 
-        for (Registration registration : student.getRegistrationsToEnrolInShiftByStudent()) {
+        Collection<Registration> registrationsToShow = null;
+
+        //This variable will be present if we are in the middle of a workflow. The registrations being listed should be limited to this registration
+        String workflowRegistrationOid = request.getParameter("workflowRegistrationOid");
+
+        if (workflowRegistrationOid != null) {
+            Registration workflowRegistation = FenixFramework.getDomainObject(workflowRegistrationOid);
+            registrationsToShow = Collections.singleton(workflowRegistation);
+            request.setAttribute("workflowRegistrationOid", workflowRegistrationOid);
+            Optional<String> returnURLForStudentInClasses =
+                    EnrolmentContextHandler.getRegisteredEnrolmentContextHandler().getReturnURLForStudentInFullClasses(request,
+                            workflowRegistation);
+            if (returnURLForStudentInClasses.isPresent()) {
+                request.setAttribute("returnURL", returnURLForStudentInClasses.get());
+            }
+        } else {
+            registrationsToShow = student.getRegistrationsToEnrolInShiftByStudent();
+        }
+
+        for (Registration registration : registrationsToShow) {
+            if (EnrolmentContextHandler.getRegisteredEnrolmentContextHandler()
+                    .getReturnURLForStudentInFullClasses(request, registration).isPresent()
+                    && !registration.getExternalId().equals(workflowRegistrationOid)) {
+                //Skip workflow based functionalities when we are not on that workflow
+                continue;
+            }
             for (EnrolmentPeriod enrolmentPeriod : registration.getActiveDegreeCurricularPlan().getEnrolmentPeriodsSet()) {
-                if (enrolmentPeriod instanceof EnrolmentPeriodInClasses && enrolmentPeriod.isValid()) {
+                if (isValidPeriodForUser(enrolmentPeriod, registration.getActiveStudentCurricularPlan())) {
                     enrollmentBeans.add(new SchoolClassStudentEnrollmentDTO(registration, enrolmentPeriod,
                             selectedEnrolmentPeriod == enrolmentPeriod ? selectedSchoolClass : null));
                 }
@@ -128,11 +158,29 @@ public class SchoolClassStudentEnrollmentDA extends FenixDispatchAction {
         return prepare(mapping, form, request, response);
     }
 
+    private boolean isValidPeriodForUser(EnrolmentPeriod ep, StudentCurricularPlan studentCurricularPlan) {
+        // Coditions to be valid:
+        // 1 - period has to be valid
+        //     AND
+        //          a - Student is candidate AND period is for candidate
+        //            OR
+        //          b - Period is for curricular courses (implicitly assuming student is not candidate)
+
+        if (ep.isValid()) {
+            if (studentCurricularPlan.isInCandidateEnrolmentProcess(ep.getExecutionPeriod().getExecutionYear())) {
+                return ep instanceof EnrolmentPeriodInClassesCandidate;
+            } else {
+                return ep.isForClasses();
+            }
+        }
+        return false;
+    }
+
     public static class SchoolClassStudentEnrollmentDTO implements Serializable, Comparable<SchoolClassStudentEnrollmentDTO> {
 
-        private Registration registration;
-        private EnrolmentPeriod enrolmentPeriod;
-        private SchoolClass schoolClassToDisplay;
+        private final Registration registration;
+        private final EnrolmentPeriod enrolmentPeriod;
+        private final SchoolClass schoolClassToDisplay;
 
         public SchoolClassStudentEnrollmentDTO(Registration registration, EnrolmentPeriod enrolmentPeriod,
                 SchoolClass schoolClassToDisplay) {

--- a/src/main/webapp/student/enrollment/schoolClass/schoolClassesSelection.jsp
+++ b/src/main/webapp/student/enrollment/schoolClass/schoolClassesSelection.jsp
@@ -32,9 +32,11 @@
 <h1><bean:message bundle="STUDENT_RESOURCES" key="title.student.shift.enrollment" /></h1>
 
 <c:if test="${not empty enrollmentBeans}">
-	<div class="alert alert-warning" role="alert"><bean:message bundle="STUDENT_RESOURCES" key="message.warning.student.enrolmentClasses" /> 
-		<html:link page="<%= "/studentEnrollmentManagement.do?method=prepare" %>" styleClass="alert-link" style="color: #7F3C00"><bean:message bundle="STUDENT_RESOURCES" key="message.warning.student.enrolmentClasses.Fenix" /></html:link>.
-	</div>
+		<c:if test="${empty workflowRegistrationOid}">		 
+			<div class="alert alert-warning" role="alert"><bean:message bundle="STUDENT_RESOURCES" key="message.warning.student.enrolmentClasses" />
+					<html:link page="<%= "/studentEnrollmentManagement.do?method=prepare" %>" styleClass="alert-link" style="color: #7F3C00"><bean:message bundle="STUDENT_RESOURCES" key="message.warning.student.enrolmentClasses.Fenix" /></html:link>.
+			</div>
+		</c:if>
 </c:if>
 <c:if test="${empty enrollmentBeans}">
 	<div class="alert alert-danger" role="alert"><bean:message bundle="STUDENT_RESOURCES" key="message.schoolClassStudentEnrollment.noOpenPeriods" /></div>
@@ -53,6 +55,12 @@
 	  <html:messages id="messages" message="true" bundle="STUDENT_RESOURCES" property="success"><bean:write name="messages" /></html:messages>
 	</div>
 </logic:messagesPresent>
+
+<logic:present name="returnURL">
+	<p>
+		<a href="${returnURL}" class="btn btn-default"><bean:message bundle="STUDENT_RESOURCES" key="link.shift.enrollment.item3" /></a>
+	</p>
+</logic:present>
 
 <c:forEach items="${enrollmentBeans}" var="enrollmentBean">
 	<c:set value="${enrollmentBean.currentSchoolClass}" var="currentSchoolClass"/>
@@ -86,7 +94,7 @@
 					<bean:define id="activeClass"><c:if test="${schoolClass eq schoolClassToDisplay}">active</c:if> q</bean:define>
 					<li class="<%= activeClass %>">
 					
-						<bean:define id="link">/schoolClassStudentEnrollment.do?method=viewSchoolClass&schoolClassID=<c:out value="${schoolClass.externalId}" />&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" /></bean:define>
+						<bean:define id="link">/schoolClassStudentEnrollment.do?method=viewSchoolClass&schoolClassID=<c:out value="${schoolClass.externalId}" />&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" /><c:if test="${not empty workflowRegistrationOid}">&workflowRegistrationOid=${workflowRegistrationOid}</c:if></bean:define>
 						<html:link page="<%= link %>">
 							<c:out value="${schoolClass.editablePartOfName}" />
 							<c:if test="${(not empty currentSchoolClass) and (schoolClass eq currentSchoolClass)}">
@@ -104,13 +112,13 @@
 				<c:choose>
 				    <c:when test="${(not empty currentSchoolClass) and (schoolClassToDisplay eq currentSchoolClass)}">
 				    	<c:set value="true" var="renderingCurrentSchoolClass"/>
-						<bean:define id="removeSchoolClassLink">/schoolClassStudentEnrollment.do?method=enrollInSchoolClass&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" /></bean:define>
+						<bean:define id="removeSchoolClassLink">/schoolClassStudentEnrollment.do?method=enrollInSchoolClass&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" /><c:if test="${not empty workflowRegistrationOid}">&workflowRegistrationOid=${workflowRegistrationOid}</c:if></bean:define>
 						<html:link page="<%= removeSchoolClassLink %>" styleClass="btn btn-warning btn-xs mtop15">
 							<span class="glyphicon glyphicon-remove" aria-hidden="true"></span> <bean:message bundle="STUDENT_RESOURCES" key="button.schoolClassStudentEnrollment.unselectSchoolClass" />
 						</html:link>			
 				    </c:when>
 				    <c:otherwise>
-						<bean:define id="selectSchoolClassLink">/schoolClassStudentEnrollment.do?method=enrollInSchoolClass&schoolClassID=<c:out value="${schoolClassToDisplay.externalId}" />&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" /></bean:define>
+						<bean:define id="selectSchoolClassLink">/schoolClassStudentEnrollment.do?method=enrollInSchoolClass&schoolClassID=<c:out value="${schoolClassToDisplay.externalId}" />&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" /><c:if test="${not empty workflowRegistrationOid}">&workflowRegistrationOid=${workflowRegistrationOid}</c:if></bean:define>
 						<bean:define id="selectSchoolClassLinkCssClass">btn btn-primary btn-xs mtop15 <c:if test="${not enrollmentBean.schoolClassToDisplayFree}">disabled</c:if></bean:define>
 						<html:link page="<%= selectSchoolClassLink %>" styleClass="<%= selectSchoolClassLinkCssClass %>">
 							<span class="glyphicon glyphicon-ok" aria-hidden="true"></span> <bean:message bundle="STUDENT_RESOURCES" key="button.schoolClassStudentEnrollment.selectSchoolClass" />
@@ -124,7 +132,7 @@
 				<c:set value="${enrollmentBean.schoolClassToDisplayLessonsJson}" var="schoolClassToDisplayLessonsJson"/>
 				<c:if test="${not empty schoolClassToDisplayLessonsJson}">
 					<c:forEach items="${enrollmentBean.schoolClassToDisplayShifts}" var="schoolClassShift">
-						<bean:define id="removeShiftLink">/schoolClassStudentEnrollment.do?method=removeShift&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" />&shiftID=<c:out value="${schoolClassShift.externalId}" /></bean:define>
+						<bean:define id="removeShiftLink">/schoolClassStudentEnrollment.do?method=removeShift&registrationID=<c:out value="${enrollmentBean.registration.externalId}" />&enrolmentPeriodID=<c:out value="${enrollmentBean.enrolmentPeriod.externalId}" />&shiftID=<c:out value="${schoolClassShift.externalId}" /><c:if test="${not empty workflowRegistrationOid}">&workflowRegistrationOid=${workflowRegistrationOid}</c:if></bean:define>
 						<html:link page="<%= removeShiftLink %>" styleClass="btn btn-danger removeShiftLink hidden" styleId="removeShiftLink-${schoolClassShift.externalId}">
 							<bean:message bundle="APPLICATION_RESOURCES" key="label.remove" />&nbsp;&nbsp;<span class="glyphicon glyphicon-remove" style="color: #FFF"></span>
 						</html:link>					 


### PR DESCRIPTION
@sanavarali please review this PR:

If the user enters during a workflow, all the requests will have a workflowRegistrationOID which will limit the registrations for which the user can enrol.

We are ignoring registrations which have a "returnURL" for normal students, this enables registrations from workflows to only appear during the workflow.