### PR TITLE
Implementing equals in StudentCurriculumModuleBean

### DIFF
--- a/src/main/java/org/fenixedu/academic/dto/student/enrollment/bolonha/StudentCurriculumGroupBean.java
+++ b/src/main/java/org/fenixedu/academic/dto/student/enrollment/bolonha/StudentCurriculumGroupBean.java
@@ -62,8 +62,11 @@ public class StudentCurriculumGroupBean extends StudentCurriculumModuleBean {
 
     private List<IDegreeModuleToEvaluate> curricularCoursesToEnrol;
 
+    private ExecutionInterval executionInterval;
+
     public StudentCurriculumGroupBean(final CurriculumGroup curriculumGroup, final ExecutionInterval executionInterval) {
         super(curriculumGroup);
+        this.executionInterval = executionInterval;
 
         setCourseGroupsToEnrol(buildCourseGroupsToEnrol(curriculumGroup, executionInterval));
 
@@ -204,6 +207,19 @@ public class StudentCurriculumGroupBean extends StudentCurriculumModuleBean {
 
     public boolean isToBeDisabled() {
         return isRoot() || !getCurriculumModule().getCurriculumModulesSet().isEmpty() || isNoCourseGroupCurriculumGroup();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof StudentCurriculumGroupBean) {
+            return ((StudentCurriculumGroupBean) obj).executionInterval == this.executionInterval && super.equals(obj);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() + this.executionInterval.hashCode();
     }
 
 }

--- a/src/main/java/org/fenixedu/academic/dto/student/enrollment/bolonha/StudentCurriculumModuleBean.java
+++ b/src/main/java/org/fenixedu/academic/dto/student/enrollment/bolonha/StudentCurriculumModuleBean.java
@@ -50,4 +50,17 @@ public abstract class StudentCurriculumModuleBean implements Serializable {
     protected Registration getRegistration() {
         return getStudentCurricularPlan().getRegistration();
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof StudentCurriculumModuleBean) {
+            return ((StudentCurriculumModuleBean) obj).curriculumModule == this.curriculumModule;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.curriculumModule.hashCode();
+    }
 }


### PR DESCRIPTION
It's interesting to implement equals (and hashCode) in these beans so
HashMaps, Sets and Caches (among others) may take advantage of them.

My idea was to consider that if two Beans are constructed exactly with
the same parameters they are the same. Not sure if there's some side
behaviour that may render this premise false.